### PR TITLE
SLING-7970 Add Feature Model introspection service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.inventory</artifactId>
+            <version>1.0.6</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>

--- a/src/main/java/org/apache/sling/feature/launcher/impl/FeatureProcessor.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/FeatureProcessor.java
@@ -19,6 +19,7 @@ package org.apache.sling.feature.launcher.impl;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,6 +43,7 @@ import org.apache.sling.feature.builder.FeatureExtensionHandler;
 import org.apache.sling.feature.io.file.ArtifactHandler;
 import org.apache.sling.feature.io.file.ArtifactManager;
 import org.apache.sling.feature.io.json.FeatureJSONReader;
+import org.apache.sling.feature.io.json.FeatureJSONWriter;
 import org.apache.sling.feature.launcher.spi.LauncherPrepareContext;
 import org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler;
 
@@ -120,7 +122,7 @@ public class FeatureProcessor {
             for(final Artifact a : entry.getValue()) {
                 final File artifactFile = ctx.getArtifactFile(a.getId());
 
-                config.getInstallation().addBundle(entry.getKey(), artifactFile);
+                config.getInstallation().addBundle(entry.getKey(), a.getId().toMvnId(), artifactFile);
             }
         }
 
@@ -137,6 +139,10 @@ public class FeatureProcessor {
                 config.getInstallation().getFrameworkProperties().put(prop.getKey(), prop.getValue());
             }
         }
+
+        StringWriter featureStringWriter = new StringWriter();
+        FeatureJSONWriter.write(featureStringWriter, app);
+        config.getInstallation().setEffectiveFeature(featureStringWriter.toString());
 
         extensions: for(final Extension ext : app.getExtensions()) {
             for (ExtensionHandler handler : ServiceLoader.load(ExtensionHandler.class,  FeatureProcessor.class.getClassLoader()))

--- a/src/main/java/org/apache/sling/feature/launcher/impl/Installation.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/Installation.java
@@ -35,7 +35,7 @@ public class Installation implements LauncherRunContext, ExtensionInstallationCo
     private final Map<String, String> fwkProperties = new HashMap<>();
 
     /** Bundle map */
-    private final Map<Integer, List<File>> bundleMap = new HashMap<>();
+    private final Map<Integer, Map<String, File>> bundleMap = new HashMap<>();
 
     /** Artifacts to be installed */
     private final List<File> installables = new ArrayList<>();
@@ -45,6 +45,9 @@ public class Installation implements LauncherRunContext, ExtensionInstallationCo
 
     /** The list of app jars. */
     private final List<File> appJars = new ArrayList<>();
+
+    /** The effective, merged feature used to launch. */
+    private String effectiveFeature;
 
     /**
      * Add an application jar.
@@ -67,13 +70,13 @@ public class Installation implements LauncherRunContext, ExtensionInstallationCo
      * @param startLevel The start level
      * @param file The bundle file
      */
-    public void addBundle(final Integer startLevel, final File file) {
-        List<File> files = bundleMap.get(startLevel);
+    public void addBundle(final Integer startLevel, final String id, final File file) {
+        Map<String, File> files = bundleMap.get(startLevel);
         if ( files == null ) {
-            files = new ArrayList<>();
+            files = new HashMap<>();
             bundleMap.put(startLevel, files);
         }
-        files.add(file);
+        files.put(id, file);
     }
 
     /**
@@ -112,7 +115,7 @@ public class Installation implements LauncherRunContext, ExtensionInstallationCo
      * @see org.apache.sling.feature.launcher.spi.LauncherRunContext#getBundleMap()
      */
     @Override
-    public Map<Integer, List<File>> getBundleMap() {
+    public Map<Integer, Map<String, File>> getBundleMap() {
         return this.bundleMap;
     }
 
@@ -133,6 +136,22 @@ public class Installation implements LauncherRunContext, ExtensionInstallationCo
     }
 
     /**
+     * @see org.apache.sling.feature.launcher.spi.LauncherRunContext#getEffectiveFeature()
+     */
+    @Override
+    public String getEffectiveFeature() {
+        return effectiveFeature;
+    }
+
+    /**
+     * Set the effective feature JSON text
+     * @param featureJsonText
+     */
+    public void setEffectiveFeature(String featureJsonText) {
+        effectiveFeature = featureJsonText;
+    }
+
+    /**
      * Clear all in-memory objects
      */
     public void clear() {
@@ -140,5 +159,6 @@ public class Installation implements LauncherRunContext, ExtensionInstallationCo
         this.fwkProperties.clear();
         this.bundleMap.clear();
         this.installables.clear();
+        this.effectiveFeature = null;
     }
 }

--- a/src/main/java/org/apache/sling/feature/launcher/impl/launchers/BaseInvocationHandler.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/launchers/BaseInvocationHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.feature.launcher.impl.launchers;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.function.Function;
+
+class BaseInvocationHandler<T> implements InvocationHandler {
+    private final String methodName;
+    private final Function<Object[], T> function;
+
+    BaseInvocationHandler(String method, Function<Object[], T> fun) {
+        methodName = method;
+        function = fun;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if (method.getName().equals(methodName)) {
+            return function.apply(args);
+        } else {
+            return method.invoke(this, args);
+        }
+    }
+}

--- a/src/main/java/org/apache/sling/feature/launcher/impl/launchers/FrameworkLauncher.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/launchers/FrameworkLauncher.java
@@ -91,7 +91,7 @@ public class FrameworkLauncher implements Launcher {
             Main.LOG().debug("Bundles:");
             for(final Integer key : context.getBundleMap().keySet()) {
                 Main.LOG().debug("-- Start Level {}", key);
-                for(final File f : context.getBundleMap().get(key)) {
+                for(final File f : context.getBundleMap().get(key).values()) {
                     Main.LOG().debug("  - {}", f.getName());
                 }
             }
@@ -116,7 +116,8 @@ public class FrameworkLauncher implements Launcher {
         Callable<Integer> restart = (Callable<Integer>) constructor.newInstance(properties,
                 context.getBundleMap(),
                 context.getConfigurations(),
-                context.getInstallableArtifacts());
+                context.getInstallableArtifacts(),
+                context.getEffectiveFeature());
 
         return restart.call();
         // nothing else to do, constructor starts everything

--- a/src/main/java/org/apache/sling/feature/launcher/impl/launchers/FrameworkRunner.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/launchers/FrameworkRunner.java
@@ -37,9 +37,10 @@ public class FrameworkRunner extends AbstractRunner {
     private volatile int type = -1;
 
     public FrameworkRunner(final Map<String, String> frameworkProperties,
-            final Map<Integer, List<File>> bundlesMap,
+            final Map<Integer, Map<String, File>> bundlesMap,
             final List<Object[]> configurations,
-            final List<File> installables) throws Exception {
+            final List<File> installables,
+            final String effectiveFeature) throws Exception {
         super(frameworkProperties, configurations, installables);
 
         final ServiceLoader<FrameworkFactory> loader = ServiceLoader.load(FrameworkFactory.class);
@@ -78,7 +79,7 @@ public class FrameworkRunner extends AbstractRunner {
             }
         });
 
-        this.setupFramework(framework, bundlesMap);
+        this.setupFramework(framework, bundlesMap, effectiveFeature);
 
 
         long time = System.currentTimeMillis();

--- a/src/main/java/org/apache/sling/feature/launcher/impl/launchers/RegisterServiceReflectively.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/launchers/RegisterServiceReflectively.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.feature.launcher.impl.launchers;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.framework.namespace.PackageNamespace;
+import org.osgi.framework.wiring.BundleCapability;
+import org.osgi.framework.wiring.BundleWiring;
+import org.osgi.util.tracker.BundleTracker;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.Dictionary;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+class RegisterServiceReflectively {
+    private final BundleContext bundleContext;
+    private final String serviceClassName;
+    private final String servicePackage;
+    private final Dictionary<String, Object> serviceProperties;
+    private final InvocationHandler invocationHandler;
+    private final BundleTracker<Bundle> bundleTracker;
+    private final Map<Bundle, ServiceRegistration<?>> registrations = new ConcurrentHashMap<>();
+
+    RegisterServiceReflectively(BundleContext bc, String className, Dictionary<String, Object> props,
+            InvocationHandler handler) {
+        bundleContext = bc;
+        serviceClassName = className;
+        servicePackage = serviceClassName.substring(0, serviceClassName.lastIndexOf('.'));
+        serviceProperties = props;
+        invocationHandler = handler;
+
+        bundleTracker = new BundleTracker<Bundle>(bc,
+                Bundle.ACTIVE | Bundle.STOPPING | Bundle.UNINSTALLED, null) {
+            @Override
+            public Bundle addingBundle(Bundle bundle, BundleEvent event) {
+                BundleWiring bw = bundle.adapt(BundleWiring.class);
+                for (BundleCapability cap : bw.getCapabilities(PackageNamespace.PACKAGE_NAMESPACE)) {
+                    if (servicePackage.equals(cap.getAttributes().get(PackageNamespace.PACKAGE_NAMESPACE))) {
+                        try {
+                            registrations.put(bundle, registerService(bw));
+                        } catch (ClassNotFoundException e) {
+                            // Ignore
+                        }
+                    }
+                }
+
+                return bundle;
+            }
+
+            @Override
+            public void modifiedBundle(Bundle bundle, BundleEvent event, Bundle object) {
+                removedBundle(bundle, event, object);
+                addingBundle(bundle, event);
+            }
+
+            @Override
+            public void removedBundle(Bundle bundle, BundleEvent event, Bundle object) {
+                ServiceRegistration<?> reg = registrations.remove(bundle);
+                if (reg != null)
+                    reg.unregister();
+            }
+        };
+    }
+
+    protected ServiceRegistration<?> registerService(BundleWiring bw) throws ClassNotFoundException {
+        Class<?> serviceClass = bw.getClassLoader().loadClass(serviceClassName);
+
+        Object proxy = Proxy.newProxyInstance(bw.getClassLoader(), new Class [] {serviceClass}, invocationHandler);
+        return bundleContext.registerService(serviceClassName, proxy, serviceProperties);
+    }
+
+    void open() {
+        bundleTracker.open();
+    }
+
+    void close() {
+        bundleTracker.close();
+    }
+}

--- a/src/main/java/org/apache/sling/feature/launcher/spi/LauncherRunContext.java
+++ b/src/main/java/org/apache/sling/feature/launcher/spi/LauncherRunContext.java
@@ -32,10 +32,11 @@ public interface LauncherRunContext {
     Map<String, String> getFrameworkProperties();
 
     /**
-     * Bundle map, key is the start level, value is a list of files.
+     * Bundle map, key is the start level, value is a map of bundle artifact
+     * ID and the local file where the bundle can be found.
      * @return The bundle map, might be empty
      */
-    Map<Integer, List<File>> getBundleMap();
+    Map<Integer, Map<String, File>> getBundleMap();
 
     /**
      * List of configurations.
@@ -55,4 +56,10 @@ public interface LauncherRunContext {
      * @return The list of files. The list might be empty.
      */
     List<File> getInstallableArtifacts();
+
+    /**
+     * Obtain the effective Feature JSON
+     * @return The effective Feature JSON as a String.
+     */
+    String getEffectiveFeature();
 }

--- a/src/main/java/org/apache/sling/feature/launcher/spi/extensions/ExtensionInstallationContext.java
+++ b/src/main/java/org/apache/sling/feature/launcher/spi/extensions/ExtensionInstallationContext.java
@@ -16,14 +16,14 @@
  */
 package org.apache.sling.feature.launcher.spi.extensions;
 
+import org.apache.sling.feature.launcher.spi.LauncherRunContext;
+
 import java.io.File;
 import java.util.Dictionary;
 
-import org.apache.sling.feature.launcher.spi.LauncherRunContext;
-
 public interface ExtensionInstallationContext extends LauncherRunContext
 {
-    public void addBundle(final Integer startLevel, final File file);
+    public void addBundle(final Integer startLevel, final String artifactId, final File file);
 
     /**
      * Add an artifact to be installed by the installer


### PR DESCRIPTION
Get the launcher to install a Felix Inventory Printer service that prints the
effective feature. This can be used to report on the selected feature.

Additionally register a service that can find the Bundle Artifact ID
from a given Bundle Symbolic Name and Version. This can be used to find
a bundle in a feature description. The interface for this service can be found here https://github.com/apache/sling-whiteboard/blob/master/featuremodel/feature-service/src/main/java/org/apache/sling/feature/service/Bundles.java