### PR TITLE
SLING-7970 Add Feature Model introspection Service API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,11 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
             <artifactId>osgi.core</artifactId>
             <version>7.0.0</version>
             <scope>provided</scope>

--- a/src/main/java/org/apache/sling/feature/launcher/impl/FeatureProcessor.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/FeatureProcessor.java
@@ -19,6 +19,7 @@ package org.apache.sling.feature.launcher.impl;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,6 +43,7 @@ import org.apache.sling.feature.builder.FeatureExtensionHandler;
 import org.apache.sling.feature.io.file.ArtifactHandler;
 import org.apache.sling.feature.io.file.ArtifactManager;
 import org.apache.sling.feature.io.json.FeatureJSONReader;
+import org.apache.sling.feature.io.json.FeatureJSONWriter;
 import org.apache.sling.feature.launcher.spi.LauncherPrepareContext;
 import org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler;
 
@@ -120,7 +122,7 @@ public class FeatureProcessor {
             for(final Artifact a : entry.getValue()) {
                 final File artifactFile = ctx.getArtifactFile(a.getId());
 
-                config.getInstallation().addBundle(entry.getKey(), artifactFile);
+                config.getInstallation().addBundle(entry.getKey(), a.getId().toMvnId(), artifactFile);
             }
         }
 
@@ -137,6 +139,10 @@ public class FeatureProcessor {
                 config.getInstallation().getFrameworkProperties().put(prop.getKey(), prop.getValue());
             }
         }
+
+        StringWriter featureStringWriter = new StringWriter();
+        FeatureJSONWriter.write(featureStringWriter, app);
+        config.getInstallation().setEffectiveFeature(featureStringWriter.toString());
 
         extensions: for(final Extension ext : app.getExtensions()) {
             for (ExtensionHandler handler : ServiceLoader.load(ExtensionHandler.class,  FeatureProcessor.class.getClassLoader()))

--- a/src/main/java/org/apache/sling/feature/launcher/impl/Installation.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/Installation.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Dictionary;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -75,7 +76,7 @@ public class Installation implements LauncherRunContext, ExtensionInstallationCo
     public void addBundle(final Integer startLevel, final String id, final File file) {
         Map<String, File> files = bundleMap.get(startLevel);
         if ( files == null ) {
-            files = new HashMap<>();
+            files = new LinkedHashMap<>();
             bundleMap.put(startLevel, files);
         }
         files.put(id, file);

--- a/src/main/java/org/apache/sling/feature/launcher/impl/Installation.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/Installation.java
@@ -35,7 +35,7 @@ public class Installation implements LauncherRunContext, ExtensionInstallationCo
     private final Map<String, String> fwkProperties = new HashMap<>();
 
     /** Bundle map */
-    private final Map<Integer, List<File>> bundleMap = new HashMap<>();
+    private final Map<Integer, Map<String, File>> bundleMap = new HashMap<>();
 
     /** Artifacts to be installed */
     private final List<File> installables = new ArrayList<>();
@@ -45,6 +45,9 @@ public class Installation implements LauncherRunContext, ExtensionInstallationCo
 
     /** The list of app jars. */
     private final List<File> appJars = new ArrayList<>();
+
+    /** The effective, merged feature used to launch. */
+    private String effectiveFeature;
 
     /**
      * Add an application jar.
@@ -65,15 +68,17 @@ public class Installation implements LauncherRunContext, ExtensionInstallationCo
     /**
      * Add a bundle with the given start level
      * @param startLevel The start level
+     * @param id The artifact ID for the bundle
      * @param file The bundle file
      */
-    public void addBundle(final Integer startLevel, final File file) {
-        List<File> files = bundleMap.get(startLevel);
+    @Override
+    public void addBundle(final Integer startLevel, final String id, final File file) {
+        Map<String, File> files = bundleMap.get(startLevel);
         if ( files == null ) {
-            files = new ArrayList<>();
+            files = new HashMap<>();
             bundleMap.put(startLevel, files);
         }
-        files.add(file);
+        files.put(id, file);
     }
 
     /**
@@ -112,7 +117,7 @@ public class Installation implements LauncherRunContext, ExtensionInstallationCo
      * @see org.apache.sling.feature.launcher.spi.LauncherRunContext#getBundleMap()
      */
     @Override
-    public Map<Integer, List<File>> getBundleMap() {
+    public Map<Integer, Map<String, File>> getBundleMap() {
         return this.bundleMap;
     }
 
@@ -133,6 +138,22 @@ public class Installation implements LauncherRunContext, ExtensionInstallationCo
     }
 
     /**
+     * @see org.apache.sling.feature.launcher.spi.LauncherRunContext#getEffectiveFeature()
+     */
+    @Override
+    public String getEffectiveFeature() {
+        return effectiveFeature;
+    }
+
+    /**
+     * Set the effective feature JSON text
+     * @param featureJsonText
+     */
+    public void setEffectiveFeature(String featureJsonText) {
+        effectiveFeature = featureJsonText;
+    }
+
+    /**
      * Clear all in-memory objects
      */
     public void clear() {
@@ -140,5 +161,6 @@ public class Installation implements LauncherRunContext, ExtensionInstallationCo
         this.fwkProperties.clear();
         this.bundleMap.clear();
         this.installables.clear();
+        this.effectiveFeature = null;
     }
 }

--- a/src/main/java/org/apache/sling/feature/launcher/impl/launchers/FrameworkRunner.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/launchers/FrameworkRunner.java
@@ -37,9 +37,10 @@ public class FrameworkRunner extends AbstractRunner {
     private volatile int type = -1;
 
     public FrameworkRunner(final Map<String, String> frameworkProperties,
-            final Map<Integer, List<File>> bundlesMap,
+            final Map<Integer, Map<String, File>> bundlesMap,
             final List<Object[]> configurations,
-            final List<File> installables) throws Exception {
+            final List<File> installables,
+            final String effectiveFeature) throws Exception {
         super(frameworkProperties, configurations, installables);
 
         final ServiceLoader<FrameworkFactory> loader = ServiceLoader.load(FrameworkFactory.class);
@@ -78,7 +79,7 @@ public class FrameworkRunner extends AbstractRunner {
             }
         });
 
-        this.setupFramework(framework, bundlesMap);
+        this.setupFramework(framework, bundlesMap, effectiveFeature);
 
 
         long time = System.currentTimeMillis();

--- a/src/main/java/org/apache/sling/feature/launcher/service/Bundles.java
+++ b/src/main/java/org/apache/sling/feature/launcher/service/Bundles.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.feature.launcher.service;
+
+/**
+ * This service provides information about bundles in the feature model.
+ */
+public interface Bundles {
+    /**
+     * Obtain the Artifact ID for a given bundle, identified by its
+     * Symbolic Name and version.
+     * @param bsn The symbolic name of the bundle.
+     * @param ver The version of the bundle.
+     * @return The artifact ID.
+     */
+    String getBundleArtifact(String bsn, String ver);
+}

--- a/src/main/java/org/apache/sling/feature/launcher/service/Features.java
+++ b/src/main/java/org/apache/sling/feature/launcher/service/Features.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.feature.launcher.service;
+
+/**
+ * The Features service provides information over Features at runtime.
+ */
+public interface Features {
+    /**
+     * Returns the effective feature as JSON text.
+     * @return The effective feature.
+     */
+    String getEffectiveFeature();
+}

--- a/src/main/java/org/apache/sling/feature/launcher/service/impl/BundlesImpl.java
+++ b/src/main/java/org/apache/sling/feature/launcher/service/impl/BundlesImpl.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.feature.launcher.service.impl;
+
+import org.apache.sling.feature.launcher.service.Bundles;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class BundlesImpl implements Bundles {
+    private final Map<Map.Entry<String, String>, String> bundleMap;
+
+    public BundlesImpl(Map<Entry<String, String>, String> bm) {
+        bundleMap = bm;
+    }
+
+    @Override
+    public String getBundleArtifact(String bsn, String ver) {
+        return bundleMap.get(new AbstractMap.SimpleEntry<String, String>(bsn, ver));
+    }
+}

--- a/src/main/java/org/apache/sling/feature/launcher/service/impl/FeaturesImpl.java
+++ b/src/main/java/org/apache/sling/feature/launcher/service/impl/FeaturesImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.feature.launcher.service.impl;
+
+import org.apache.sling.feature.launcher.service.Features;
+
+public class FeaturesImpl implements Features {
+    private final String effectiveFeature;
+
+    public FeaturesImpl(String feat) {
+        effectiveFeature = feat;
+    }
+
+    @Override
+    public String getEffectiveFeature() {
+        return effectiveFeature;
+    }
+}

--- a/src/main/java/org/apache/sling/feature/launcher/service/package-info.java
+++ b/src/main/java/org/apache/sling/feature/launcher/service/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+@org.osgi.annotation.versioning.Version("0.1.0")
+package org.apache.sling.feature.launcher.service;
+
+

--- a/src/main/java/org/apache/sling/feature/launcher/spi/LauncherRunContext.java
+++ b/src/main/java/org/apache/sling/feature/launcher/spi/LauncherRunContext.java
@@ -32,10 +32,11 @@ public interface LauncherRunContext {
     Map<String, String> getFrameworkProperties();
 
     /**
-     * Bundle map, key is the start level, value is a list of files.
+     * Bundle map, key is the start level, value is a map of bundle artifact
+     * ID and the local file where the bundle can be found.
      * @return The bundle map, might be empty
      */
-    Map<Integer, List<File>> getBundleMap();
+    Map<Integer, Map<String, File>> getBundleMap();
 
     /**
      * List of configurations.
@@ -55,4 +56,10 @@ public interface LauncherRunContext {
      * @return The list of files. The list might be empty.
      */
     List<File> getInstallableArtifacts();
+
+    /**
+     * Obtain the effective Feature JSON
+     * @return The effective Feature JSON as a String.
+     */
+    String getEffectiveFeature();
 }

--- a/src/main/java/org/apache/sling/feature/launcher/spi/extensions/ExtensionInstallationContext.java
+++ b/src/main/java/org/apache/sling/feature/launcher/spi/extensions/ExtensionInstallationContext.java
@@ -23,7 +23,13 @@ import org.apache.sling.feature.launcher.spi.LauncherRunContext;
 
 public interface ExtensionInstallationContext extends LauncherRunContext
 {
-    public void addBundle(final Integer startLevel, final File file);
+    /**
+     * Add a bundle with the given start level
+     * @param startLevel The start level
+     * @param id The artifact ID for the bundle
+     * @param file The bundle file
+     */
+    public void addBundle(final Integer startLevel, final String artifactId, final File file);
 
     /**
      * Add an artifact to be installed by the installer


### PR DESCRIPTION
The API has two services:
1. A Features service that provides the effective feature run as JSON
2. A Bundles service that allows the lookup of a Bundle artifact ID as
represented in the feature model from a BSN and Version.
Right now the Service API is embedded in the launcher. We could
potentially isolate it in a separate module in the future.