### PR TITLE
SLING-8334 Get Launcher Extension API ready for 1.0 release

### DIFF
--- a/src/main/java/org/apache/sling/feature/launcher/impl/ExtensionContextImpl.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/ExtensionContextImpl.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.sling.feature.launcher.impl;
+
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.io.json.FeatureJSONReader;
+import org.apache.sling.feature.launcher.spi.LauncherPrepareContext;
+import org.apache.sling.feature.launcher.spi.extensions.ExtensionContext;
+import org.apache.sling.feature.launcher.spi.extensions.ExtensionInstallationContext;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Dictionary;
+import java.util.List;
+import java.util.Map;
+
+class ExtensionContextImpl implements ExtensionContext {
+    private final ExtensionInstallationContext installationContext;
+    private final LauncherPrepareContext prepareContext;
+
+    ExtensionContextImpl(LauncherPrepareContext lpc, ExtensionInstallationContext eic) {
+        prepareContext = lpc;
+        installationContext = eic;
+    }
+
+    @Override
+    public void addBundle(Integer startLevel, File file) {
+        installationContext.addBundle(startLevel, file);
+    }
+
+    @Override
+    public void addInstallableArtifact(File file) {
+        installationContext.addInstallableArtifact(file);
+    }
+
+    @Override
+    public void addConfiguration(String pid, String factoryPid, Dictionary<String, Object> properties) {
+        installationContext.addConfiguration(pid, factoryPid, properties);
+    }
+
+    @Override
+    public void addFrameworkProperty(String key, String value) {
+        installationContext.addFrameworkProperty(key, value);
+    }
+
+    @Override
+    public Map<String, String> getFrameworkProperties() {
+        return installationContext.getFrameworkProperties();
+    }
+
+    @Override
+    public Map<Integer, List<File>> getBundleMap() {
+        return installationContext.getBundleMap();
+    }
+
+    @Override
+    public List<Object[]> getConfigurations() {
+        return installationContext.getConfigurations();
+    }
+
+    @Override
+    public List<File> getInstallableArtifacts() {
+        return installationContext.getInstallableArtifacts();
+    }
+
+    @Override
+    public void addAppJar(File jar) {
+        prepareContext.addAppJar(jar);
+    }
+
+    @Override
+    public File getArtifactFile(ArtifactId artifact) throws IOException {
+        return prepareContext.getArtifactFile(artifact);
+    }
+
+    @Override
+    public Feature getFeature(ArtifactId artifact) throws IOException {
+        // TODO this can in theory be optimized since we have already parsed some features
+        File file = getArtifactFile(artifact);
+        if (file == null)
+            return null;
+
+        try (FileReader r = new FileReader(file)) {
+            return FeatureJSONReader.read(r, artifact.toMvnUrl());
+        }
+    }
+}

--- a/src/main/java/org/apache/sling/feature/launcher/impl/FeatureProcessor.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/FeatureProcessor.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -156,7 +155,7 @@ public class FeatureProcessor {
         extensions: for(final Extension ext : app.getExtensions()) {
             for (ExtensionHandler handler : ServiceLoader.load(ExtensionHandler.class,  FeatureProcessor.class.getClassLoader()))
             {
-                if (handler.handle(ext, ctx, config.getInstallation())) {
+                if (handler.handle(new ExtensionContextImpl(ctx, config.getInstallation()), ext)) {
                     continue extensions;
                 }
             }

--- a/src/main/java/org/apache/sling/feature/launcher/impl/extensions/handlers/ContentPackageHandler.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/extensions/handlers/ContentPackageHandler.java
@@ -16,24 +16,23 @@
  */
 package org.apache.sling.feature.launcher.impl.extensions.handlers;
 
-import java.io.IOException;
-
 import org.apache.sling.feature.Artifact;
 import org.apache.sling.feature.Extension;
 import org.apache.sling.feature.ExtensionType;
-import org.apache.sling.feature.launcher.spi.LauncherPrepareContext;
+import org.apache.sling.feature.launcher.spi.extensions.ExtensionContext;
 import org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler;
-import org.apache.sling.feature.launcher.spi.extensions.ExtensionInstallationContext;
+
+import java.io.IOException;
 
 public class ContentPackageHandler implements ExtensionHandler
 {
     @Override
-    public boolean handle(Extension extension, LauncherPrepareContext prepareContext, ExtensionInstallationContext installationContext) throws IOException
+    public boolean handle(ExtensionContext context, Extension extension) throws IOException
     {
         if (extension.getType() == ExtensionType.ARTIFACTS
                 && extension.getName().equals(Extension.EXTENSION_NAME_CONTENT_PACKAGES)) {
             for(final Artifact a : extension.getArtifacts() ) {
-                installationContext.addInstallableArtifact(prepareContext.getArtifactFile(a.getId()));
+                context.addInstallableArtifact(context.getArtifactFile(a.getId()));
             }
             return true;
         }

--- a/src/main/java/org/apache/sling/feature/launcher/impl/extensions/handlers/RepoInitHandler.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/extensions/handlers/RepoInitHandler.java
@@ -16,21 +16,20 @@
  */
 package org.apache.sling.feature.launcher.impl.extensions.handlers;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.sling.feature.Configuration;
 import org.apache.sling.feature.Extension;
 import org.apache.sling.feature.ExtensionType;
-import org.apache.sling.feature.launcher.spi.LauncherPrepareContext;
+import org.apache.sling.feature.launcher.spi.extensions.ExtensionContext;
 import org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler;
-import org.apache.sling.feature.launcher.spi.extensions.ExtensionInstallationContext;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class RepoInitHandler implements ExtensionHandler
 {
     private static final AtomicInteger index = new AtomicInteger(1);
 
     @Override
-    public boolean handle(Extension extension, LauncherPrepareContext prepareContext, ExtensionInstallationContext installationContext) throws Exception
+    public boolean handle(ExtensionContext context, Extension extension) throws Exception
     {
         if (extension.getName().equals(Extension.EXTENSION_NAME_REPOINIT)) {
             if ( extension.getType() != ExtensionType.TEXT ) {
@@ -39,7 +38,7 @@ public class RepoInitHandler implements ExtensionHandler
             final Configuration cfg = new Configuration("org.apache.sling.jcr.repoinit.RepositoryInitializer~repoinit"
                     + String.valueOf(index.getAndIncrement()));
             cfg.getProperties().put("scripts", extension.getText());
-            installationContext.addConfiguration(Configuration.getName(cfg.getPid()),
+            context.addConfiguration(Configuration.getName(cfg.getPid()),
                     Configuration.getFactoryPid(cfg.getPid()), cfg.getConfigurationProperties());
             return true;
         }

--- a/src/main/java/org/apache/sling/feature/launcher/spi/extensions/ExtensionContext.java
+++ b/src/main/java/org/apache/sling/feature/launcher/spi/extensions/ExtensionContext.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.sling.feature.launcher.spi.extensions;
+
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.launcher.spi.LauncherPrepareContext;
+
+import java.io.IOException;
+
+/**
+ * This context object is provided to launcher extensions.
+ */
+public interface ExtensionContext extends LauncherPrepareContext, ExtensionInstallationContext {
+    /**
+     * Return the feature object for a given Artifact ID. It looks for the requested feature
+     * in the list of features provided from the launcher commandline as well as in the configured
+     * repositories.
+     * @param artifact The artifact ID for the feature.
+     * @return The Feature Model or null if the artifact cannot be found.
+     * @throws IOException If the artifact can be found, but creating a Feature
+     * Model out of it causes an exception.
+     */
+    Feature getFeature(ArtifactId artifact) throws IOException;
+}

--- a/src/main/java/org/apache/sling/feature/launcher/spi/extensions/ExtensionHandler.java
+++ b/src/main/java/org/apache/sling/feature/launcher/spi/extensions/ExtensionHandler.java
@@ -17,9 +17,8 @@
 package org.apache.sling.feature.launcher.spi.extensions;
 
 import org.apache.sling.feature.Extension;
-import org.apache.sling.feature.launcher.spi.LauncherPrepareContext;
 
 public interface ExtensionHandler
 {
-    public boolean handle(Extension extension, LauncherPrepareContext prepareContext, ExtensionInstallationContext installationContext) throws Exception;
+    public boolean handle(ExtensionContext context, Extension extension) throws Exception;
 }


### PR DESCRIPTION
The extensions now get provided with a single ExtensionContext object
that combines the functionality that was previously spread over the
LauncherPrepareContext and ExtensionInstallationContext.
Additionally, a lookup is provided for a Feature Model based on Artifact
ID. This can be used by extension plugins to read feature models
referenced in an extension.