### PR TITLE
SLING-8334 Get Launcher Extension API ready for 1.0 release

### DIFF
--- a/src/main/java/org/apache/sling/feature/launcher/impl/ExtensionContextImpl.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/ExtensionContextImpl.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.sling.feature.launcher.impl;
+
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.io.json.FeatureJSONReader;
+import org.apache.sling.feature.launcher.spi.LauncherPrepareContext;
+import org.apache.sling.feature.launcher.spi.extensions.ExtensionContext;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Dictionary;
+import java.util.List;
+import java.util.Map;
+
+class ExtensionContextImpl implements ExtensionContext {
+    private final Installation installation;
+    private final LauncherPrepareContext prepareContext;
+    private final Map<ArtifactId, Feature> loadedFeatures;
+
+    ExtensionContextImpl(LauncherPrepareContext lpc, Installation inst, Map<ArtifactId, Feature> featureMap) {
+        prepareContext = lpc;
+        installation = inst;
+        loadedFeatures = featureMap;
+    }
+
+    @Override
+    public void addBundle(Integer startLevel, File file) {
+        installation.addBundle(startLevel, file);
+    }
+
+    @Override
+    public void addInstallableArtifact(File file) {
+        installation.addInstallableArtifact(file);
+    }
+
+    @Override
+    public void addConfiguration(String pid, String factoryPid, Dictionary<String, Object> properties) {
+        installation.addConfiguration(pid, factoryPid, properties);
+    }
+
+    @Override
+    public void addFrameworkProperty(String key, String value) {
+        installation.addFrameworkProperty(key, value);
+    }
+
+    @Override
+    public Map<String, String> getFrameworkProperties() {
+        return installation.getFrameworkProperties();
+    }
+
+    @Override
+    public Map<Integer, List<File>> getBundleMap() {
+        return installation.getBundleMap();
+    }
+
+    @Override
+    public List<Object[]> getConfigurations() {
+        return installation.getConfigurations();
+    }
+
+    @Override
+    public List<File> getInstallableArtifacts() {
+        return installation.getInstallableArtifacts();
+    }
+
+    @Override
+    public void addAppJar(File jar) {
+        prepareContext.addAppJar(jar);
+    }
+
+    @Override
+    public File getArtifactFile(ArtifactId artifact) throws IOException {
+        return prepareContext.getArtifactFile(artifact);
+    }
+
+    @Override
+    public Feature getFeature(ArtifactId artifact) throws IOException {
+        Feature f = loadedFeatures.get(artifact);
+        if (f != null)
+            return f;
+
+        File file = getArtifactFile(artifact);
+        if (file == null)
+            return null;
+
+        try (FileReader r = new FileReader(file)) {
+            return FeatureJSONReader.read(r, artifact.toMvnUrl());
+        }
+    }
+}

--- a/src/main/java/org/apache/sling/feature/launcher/impl/Installation.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/Installation.java
@@ -16,6 +16,8 @@
  */
 package org.apache.sling.feature.launcher.impl;
 
+import org.apache.sling.feature.launcher.spi.LauncherRunContext;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Dictionary;
@@ -23,13 +25,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.sling.feature.launcher.spi.LauncherRunContext;
-import org.apache.sling.feature.launcher.spi.extensions.ExtensionInstallationContext;
-
 /**
  * This class holds the configuration of the launcher.
  */
-public class Installation implements LauncherRunContext, ExtensionInstallationContext {
+public class Installation implements LauncherRunContext {
 
     /** The map with the framework properties. */
     private final Map<String, String> fwkProperties = new HashMap<>();
@@ -102,7 +101,6 @@ public class Installation implements LauncherRunContext, ExtensionInstallationCo
         return this.fwkProperties;
     }
 
-    @Override
     public void addFrameworkProperty(String key, String value)
     {
         this.fwkProperties.put(key, value);

--- a/src/main/java/org/apache/sling/feature/launcher/impl/Main.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/Main.java
@@ -23,7 +23,9 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
@@ -224,7 +226,8 @@ public class Main {
             try {
                 boolean restart = launcherConfig.getFeatureFiles().length == 0;
 
-                final Feature app = assemble(launcherConfig, artifactManager);
+                Map<ArtifactId, Feature> loadedFeatures = new HashMap<>();
+                final Feature app = assemble(launcherConfig, artifactManager, loadedFeatures);
 
                 Main.LOG().info("");
                 Main.LOG().info("Assembling launcher...");
@@ -247,7 +250,7 @@ public class Main {
 
                 launcher.prepare(ctx, getFelixFrameworkId(m_frameworkVersion), app);
 
-                FeatureProcessor.prepareLauncher(ctx, launcherConfig, app);
+                FeatureProcessor.prepareLauncher(ctx, launcherConfig, app, loadedFeatures);
 
                 Main.LOG().info("Using {} local artifacts, {} cached artifacts, and {} downloaded artifacts",
                     launcherConfig.getLocalArtifacts(), launcherConfig.getCachedArtifacts(), launcherConfig.getDownloadedArtifacts());
@@ -275,7 +278,8 @@ public class Main {
         }
     }
 
-    private static Feature assemble(final LauncherConfig launcherConfig, final ArtifactManager artifactManager) throws IOException
+    private static Feature assemble(final LauncherConfig launcherConfig, final ArtifactManager artifactManager,
+            Map<ArtifactId, Feature> loadedFeatures) throws IOException
     {
         if (launcherConfig.getFeatureFiles().length == 0) {
             File application = getApplicationFeatureFile(launcherConfig);
@@ -285,11 +289,11 @@ public class Main {
             else {
                 throw new IllegalStateException("No feature(s) to launch found and none where specified");
             }
-            return FeatureProcessor.createApplication(launcherConfig, artifactManager);
+            return FeatureProcessor.createApplication(launcherConfig, artifactManager, loadedFeatures);
         }
         else
         {
-            final Feature app = FeatureProcessor.createApplication(launcherConfig, artifactManager);
+            final Feature app = FeatureProcessor.createApplication(launcherConfig, artifactManager, loadedFeatures);
 
             // write application back
             final File file = getApplicationFeatureFile(launcherConfig);

--- a/src/main/java/org/apache/sling/feature/launcher/impl/extensions/handlers/ContentPackageHandler.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/extensions/handlers/ContentPackageHandler.java
@@ -21,19 +21,18 @@ import java.io.IOException;
 import org.apache.sling.feature.Artifact;
 import org.apache.sling.feature.Extension;
 import org.apache.sling.feature.ExtensionType;
-import org.apache.sling.feature.launcher.spi.LauncherPrepareContext;
+import org.apache.sling.feature.launcher.spi.extensions.ExtensionContext;
 import org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler;
-import org.apache.sling.feature.launcher.spi.extensions.ExtensionInstallationContext;
 
 public class ContentPackageHandler implements ExtensionHandler
 {
     @Override
-    public boolean handle(Extension extension, LauncherPrepareContext prepareContext, ExtensionInstallationContext installationContext) throws IOException
+    public boolean handle(ExtensionContext context, Extension extension) throws IOException
     {
         if (extension.getType() == ExtensionType.ARTIFACTS
                 && extension.getName().equals(Extension.EXTENSION_NAME_CONTENT_PACKAGES)) {
             for(final Artifact a : extension.getArtifacts() ) {
-                installationContext.addInstallableArtifact(prepareContext.getArtifactFile(a.getId()));
+                context.addInstallableArtifact(context.getArtifactFile(a.getId()));
             }
             return true;
         }

--- a/src/main/java/org/apache/sling/feature/launcher/impl/extensions/handlers/RepoInitHandler.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/extensions/handlers/RepoInitHandler.java
@@ -21,16 +21,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.sling.feature.Configuration;
 import org.apache.sling.feature.Extension;
 import org.apache.sling.feature.ExtensionType;
-import org.apache.sling.feature.launcher.spi.LauncherPrepareContext;
+import org.apache.sling.feature.launcher.spi.extensions.ExtensionContext;
 import org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler;
-import org.apache.sling.feature.launcher.spi.extensions.ExtensionInstallationContext;
 
 public class RepoInitHandler implements ExtensionHandler
 {
     private static final AtomicInteger index = new AtomicInteger(1);
 
     @Override
-    public boolean handle(Extension extension, LauncherPrepareContext prepareContext, ExtensionInstallationContext installationContext) throws Exception
+    public boolean handle(ExtensionContext context, Extension extension) throws Exception
     {
         if (extension.getName().equals(Extension.EXTENSION_NAME_REPOINIT)) {
             if ( extension.getType() != ExtensionType.TEXT ) {
@@ -39,7 +38,7 @@ public class RepoInitHandler implements ExtensionHandler
             final Configuration cfg = new Configuration("org.apache.sling.jcr.repoinit.RepositoryInitializer~repoinit"
                     + String.valueOf(index.getAndIncrement()));
             cfg.getProperties().put("scripts", extension.getText());
-            installationContext.addConfiguration(Configuration.getName(cfg.getPid()),
+            context.addConfiguration(Configuration.getName(cfg.getPid()),
                     Configuration.getFactoryPid(cfg.getPid()), cfg.getConfigurationProperties());
             return true;
         }

--- a/src/main/java/org/apache/sling/feature/launcher/spi/extensions/ExtensionContext.java
+++ b/src/main/java/org/apache/sling/feature/launcher/spi/extensions/ExtensionContext.java
@@ -16,28 +16,55 @@
  */
 package org.apache.sling.feature.launcher.spi.extensions;
 
-import java.io.File;
-import java.util.Dictionary;
-
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.launcher.spi.LauncherPrepareContext;
 import org.apache.sling.feature.launcher.spi.LauncherRunContext;
 
-public interface ExtensionInstallationContext extends LauncherRunContext
-{
+import java.io.File;
+import java.io.IOException;
+import java.util.Dictionary;
+
+/**
+ * This context object is provided to launcher extensions.
+ */
+public interface ExtensionContext extends LauncherPrepareContext, LauncherRunContext {
+    /**
+     * Add a bundle to be installed by the launcher.
+     * @param startLevel The start level for the bundle.
+     * @param file The file with the bundle.
+     */
     public void addBundle(final Integer startLevel, final File file);
 
     /**
-     * Add an artifact to be installed by the installer
+     * Add an artifact to be installed by the launcher
      * @param file The file
      */
     public void addInstallableArtifact(final File file);
 
     /**
-     * Add a configuration
+     * Add a configuration to be installed by the launcher
      * @param pid The pid
      * @param factoryPid The factory pid
      * @param properties The propertis
      */
     public void addConfiguration(final String pid, final String factoryPid, final Dictionary<String, Object> properties);
 
+    /**
+     * Add a framework property to be set by the launcher.
+     * @param key The key for the property.
+     * @param value The value for the property.
+     */
     public void addFrameworkProperty(final String key, final String value);
+
+    /**
+     * Return the feature object for a given Artifact ID. It looks for the requested feature
+     * in the list of features provided from the launcher commandline as well as in the configured
+     * repositories.
+     * @param artifact The artifact ID for the feature.
+     * @return The Feature Model or null if the artifact cannot be found.
+     * @throws IOException If the artifact can be found, but creating a Feature
+     * Model out of it causes an exception.
+     */
+    Feature getFeature(ArtifactId artifact) throws IOException;
 }

--- a/src/main/java/org/apache/sling/feature/launcher/spi/extensions/ExtensionHandler.java
+++ b/src/main/java/org/apache/sling/feature/launcher/spi/extensions/ExtensionHandler.java
@@ -17,9 +17,8 @@
 package org.apache.sling.feature.launcher.spi.extensions;
 
 import org.apache.sling.feature.Extension;
-import org.apache.sling.feature.launcher.spi.LauncherPrepareContext;
 
 public interface ExtensionHandler
 {
-    public boolean handle(Extension extension, LauncherPrepareContext prepareContext, ExtensionInstallationContext installationContext) throws Exception;
+    public boolean handle(ExtensionContext context, Extension extension) throws Exception;
 }

--- a/src/test/java/org/apache/sling/feature/launcher/impl/ExtensionContextImplTest.java
+++ b/src/test/java/org/apache/sling/feature/launcher/impl/ExtensionContextImplTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.sling.feature.launcher.impl;
+
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.launcher.spi.LauncherPrepareContext;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class ExtensionContextImplTest {
+    @Test
+    public void testGetFeature() throws Exception {
+        File testFeatureFile = new File(getClass().getResource("/test-feature.json").getFile());
+
+        ArtifactId aid2 = ArtifactId.fromMvnId("g:a:2");
+        LauncherPrepareContext lpc = Mockito.mock(LauncherPrepareContext.class);
+        Mockito.when(lpc.getArtifactFile(aid2)).thenReturn(testFeatureFile);
+
+        ArtifactId aid1 = ArtifactId.fromMvnId("g:a:1");
+        Feature f1 = new Feature(aid1);
+        Map<ArtifactId, Feature> loaded = new HashMap<>();
+        loaded.put(aid1, f1);
+
+        ExtensionContextImpl c = new ExtensionContextImpl(lpc, null, loaded);
+        assertEquals(f1, c.getFeature(aid1));
+        assertNotNull(c.getFeature(aid2));
+        assertNull(c.getFeature(ArtifactId.fromMvnId("g:a:3")));
+    }
+}

--- a/src/test/resources/test-feature.json
+++ b/src/test/resources/test-feature.json
@@ -1,0 +1,3 @@
+{
+    "id" : "org.apache.sling/a-test-feature/1"
+}


### PR DESCRIPTION
The extensions now get provided with a single ExtensionContext object
that combines the functionality that was previously spread over the
LauncherPrepareContext and ExtensionInstallationContext.
Additionally, a lookup is provided for a Feature Model based on Artifact
ID. This can be used by extension plugins to read feature models
referenced in an extension.