### PR TITLE
Issues/sling 8483 Add a Priority to the Extension Handler to sort them

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
                     <excludes>
                         <exclude>readme.md</exclude>
                         <exclude>src/main/resources/META-INF/services/**</exclude>
+                        <exclude>src/test/resources/META-INF/services/**</exclude>
                         <exclude>**/*.properties</exclude>
                         <exclude>launcher/**</exclude>
                     </excludes>

--- a/src/main/java/org/apache/sling/feature/launcher/impl/FeatureProcessor.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/FeatureProcessor.java
@@ -22,6 +22,7 @@ import java.io.Reader;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -165,13 +166,13 @@ public class FeatureProcessor {
         }
 
         extensions: for(final Extension ext : app.getExtensions()) {
-            List<ExtensionHandler> extensionHandlerList = new ArrayList<>();
-            for (ExtensionHandler handler : ServiceLoader.load(ExtensionHandler.class,  FeatureProcessor.class.getClassLoader())) {
-                extensionHandlerList.add(handler);
-            }
-            List<ExtensionHandler> prioritizedExtensionHandlerList = extensionHandlerList.stream()
-                .sorted(Comparator.comparingInt(ExtensionHandler::getPriority).reversed())
-                .collect(Collectors.toList());
+            Iterator<ExtensionHandler> i = ServiceLoader.load(ExtensionHandler.class,  FeatureProcessor.class.getClassLoader()).iterator();
+            // Stream the iterator, sort them based on Priority in reversed order and then collection into a list
+            List<ExtensionHandler> prioritizedExtensionHandlerList =
+                StreamSupport
+                    .stream(Spliterators.spliteratorUnknownSize(i, Spliterator.ORDERED), false)
+                    .sorted(Comparator.comparingInt(ExtensionHandler::getPriority).reversed())
+                    .collect(Collectors.toList());
             for (ExtensionHandler handler : prioritizedExtensionHandlerList)
             {
                 if (handler.handle(new ExtensionContextImpl(ctx, config.getInstallation(), loadedFeatures), ext)) {

--- a/src/main/java/org/apache/sling/feature/launcher/impl/FeatureProcessor.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/FeatureProcessor.java
@@ -21,11 +21,13 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.apache.sling.feature.Artifact;
@@ -163,7 +165,14 @@ public class FeatureProcessor {
         }
 
         extensions: for(final Extension ext : app.getExtensions()) {
-            for (ExtensionHandler handler : ServiceLoader.load(ExtensionHandler.class,  FeatureProcessor.class.getClassLoader()))
+            List<ExtensionHandler> extensionHandlerList = new ArrayList<>();
+            for (ExtensionHandler handler : ServiceLoader.load(ExtensionHandler.class,  FeatureProcessor.class.getClassLoader())) {
+                extensionHandlerList.add(handler);
+            }
+            List<ExtensionHandler> prioritizedExtensionHandlerList = extensionHandlerList.stream()
+                .sorted(Comparator.comparingInt(ExtensionHandler::getPriority).reversed())
+                .collect(Collectors.toList());
+            for (ExtensionHandler handler : prioritizedExtensionHandlerList)
             {
                 if (handler.handle(new ExtensionContextImpl(ctx, config.getInstallation(), loadedFeatures), ext)) {
                     continue extensions;

--- a/src/main/java/org/apache/sling/feature/launcher/impl/extensions/handlers/ContentPackageHandler.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/extensions/handlers/ContentPackageHandler.java
@@ -27,6 +27,11 @@ import org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler;
 public class ContentPackageHandler implements ExtensionHandler
 {
     @Override
+    public int getPriority() {
+        return FALLBACK_PRIORITY;
+    }
+
+    @Override
     public boolean handle(ExtensionContext context, Extension extension) throws IOException
     {
         if (extension.getType() == ExtensionType.ARTIFACTS

--- a/src/main/java/org/apache/sling/feature/launcher/impl/extensions/handlers/RepoInitHandler.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/extensions/handlers/RepoInitHandler.java
@@ -29,6 +29,11 @@ public class RepoInitHandler implements ExtensionHandler
     private static final AtomicInteger index = new AtomicInteger(1);
 
     @Override
+    public int getPriority() {
+        return FALLBACK_PRIORITY;
+    }
+
+    @Override
     public boolean handle(ExtensionContext context, Extension extension) throws Exception
     {
         if (extension.getName().equals(Extension.EXTENSION_NAME_REPOINIT)) {

--- a/src/main/java/org/apache/sling/feature/launcher/spi/extensions/ExtensionHandler.java
+++ b/src/main/java/org/apache/sling/feature/launcher/spi/extensions/ExtensionHandler.java
@@ -20,5 +20,11 @@ import org.apache.sling.feature.Extension;
 
 public interface ExtensionHandler
 {
+    /** Priority for Extension Handlers that are just a fallback instance **/
+    int FALLBACK_PRIORITY = -1;
+
+    /** @return The priority of the Extension Handler to select the most appropriate one. The one with the highest priority is selected **/
+    int getPriority();
+
     public boolean handle(ExtensionContext context, Extension extension) throws Exception;
 }

--- a/src/test/java/org/apache/sling/feature/launcher/handler/ExtensionHandler100.java
+++ b/src/test/java/org/apache/sling/feature/launcher/handler/ExtensionHandler100.java
@@ -1,0 +1,15 @@
+package org.apache.sling.feature.launcher.handler;
+
+import org.apache.sling.feature.Extension;
+import org.apache.sling.feature.launcher.spi.extensions.ExtensionContext;
+import org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler;
+
+public class ExtensionHandler100
+    extends ExtensionHandlerBase
+    implements ExtensionHandler
+{
+    @Override
+    public int getPriority() {
+        return 100;
+    }
+}

--- a/src/test/java/org/apache/sling/feature/launcher/handler/ExtensionHandler100.java
+++ b/src/test/java/org/apache/sling/feature/launcher/handler/ExtensionHandler100.java
@@ -1,12 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.sling.feature.launcher.handler;
-
-import org.apache.sling.feature.Extension;
-import org.apache.sling.feature.launcher.spi.extensions.ExtensionContext;
-import org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler;
 
 public class ExtensionHandler100
     extends ExtensionHandlerBase
-    implements ExtensionHandler
 {
     @Override
     public int getPriority() {

--- a/src/test/java/org/apache/sling/feature/launcher/handler/ExtensionHandler200.java
+++ b/src/test/java/org/apache/sling/feature/launcher/handler/ExtensionHandler200.java
@@ -1,12 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.sling.feature.launcher.handler;
-
-import org.apache.sling.feature.Extension;
-import org.apache.sling.feature.launcher.spi.extensions.ExtensionContext;
-import org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler;
 
 public class ExtensionHandler200
     extends ExtensionHandlerBase
-    implements ExtensionHandler
 {
     @Override
     public int getPriority() {

--- a/src/test/java/org/apache/sling/feature/launcher/handler/ExtensionHandler200.java
+++ b/src/test/java/org/apache/sling/feature/launcher/handler/ExtensionHandler200.java
@@ -1,0 +1,15 @@
+package org.apache.sling.feature.launcher.handler;
+
+import org.apache.sling.feature.Extension;
+import org.apache.sling.feature.launcher.spi.extensions.ExtensionContext;
+import org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler;
+
+public class ExtensionHandler200
+    extends ExtensionHandlerBase
+    implements ExtensionHandler
+{
+    @Override
+    public int getPriority() {
+        return 200;
+    }
+}

--- a/src/test/java/org/apache/sling/feature/launcher/handler/ExtensionHandlerBase.java
+++ b/src/test/java/org/apache/sling/feature/launcher/handler/ExtensionHandlerBase.java
@@ -1,0 +1,22 @@
+package org.apache.sling.feature.launcher.handler;
+
+import org.apache.sling.feature.Extension;
+import org.apache.sling.feature.launcher.spi.extensions.ExtensionContext;
+import org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler;
+
+public abstract class ExtensionHandlerBase
+    implements ExtensionHandler
+{
+    private static int lastPriorityUsed = -100;
+
+    public static int getLastPriorityUsed() {
+        return lastPriorityUsed;
+    }
+
+    @Override
+    public boolean handle(ExtensionContext context, Extension extension) throws Exception {
+        boolean answer = lastPriorityUsed == -100;
+        lastPriorityUsed = getPriority();
+        return answer;
+    }
+}

--- a/src/test/java/org/apache/sling/feature/launcher/handler/ExtensionHandlerBase.java
+++ b/src/test/java/org/apache/sling/feature/launcher/handler/ExtensionHandlerBase.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.sling.feature.launcher.handler;
 
 import org.apache.sling.feature.Extension;

--- a/src/test/java/org/apache/sling/feature/launcher/handler/ExtensionHandlerDefault.java
+++ b/src/test/java/org/apache/sling/feature/launcher/handler/ExtensionHandlerDefault.java
@@ -1,0 +1,13 @@
+package org.apache.sling.feature.launcher.handler;
+
+import org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler;
+
+public class ExtensionHandlerDefault
+    extends ExtensionHandlerBase
+    implements ExtensionHandler
+{
+    @Override
+    public int getPriority() {
+        return FALLBACK_PRIORITY;
+    }
+}

--- a/src/test/java/org/apache/sling/feature/launcher/handler/ExtensionHandlerDefault.java
+++ b/src/test/java/org/apache/sling/feature/launcher/handler/ExtensionHandlerDefault.java
@@ -1,10 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.sling.feature.launcher.handler;
-
-import org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler;
 
 public class ExtensionHandlerDefault
     extends ExtensionHandlerBase
-    implements ExtensionHandler
 {
     @Override
     public int getPriority() {

--- a/src/test/java/org/apache/sling/feature/launcher/impl/FeatureProcessorTest.java
+++ b/src/test/java/org/apache/sling/feature/launcher/impl/FeatureProcessorTest.java
@@ -1,0 +1,47 @@
+package org.apache.sling.feature.launcher.impl;
+
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Extension;
+import org.apache.sling.feature.ExtensionType;
+import org.apache.sling.feature.Extensions;
+import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.launcher.handler.ExtensionHandlerBase;
+import org.apache.sling.feature.launcher.spi.LauncherPrepareContext;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class FeatureProcessorTest {
+
+    private Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Test
+    public void testExtensionHandlerSorting() throws Exception {
+        LauncherPrepareContext mockContext = mock(LauncherPrepareContext.class);
+        LauncherConfig mockConfig = mock(LauncherConfig.class);
+        Feature feature = spy(new Feature(new ArtifactId("g", "a","1.0.0", "test", "jar" )));
+        Map<ArtifactId, Feature> loadedFeatures = new HashMap<>();
+        Extension extension = new Extension(
+            ExtensionType.TEXT,
+            "ContentHandler",
+            true
+        );
+        Extensions extensions = new Extensions();
+        extensions.add(extension);
+        when(feature.getExtensions()).thenReturn(extensions);
+
+        FeatureProcessor.prepareLauncher(
+            mockContext, mockConfig, feature, loadedFeatures
+        );
+        logger.info("Last Priority Used: '{}'", ExtensionHandlerBase.getLastPriorityUsed());
+        assertEquals("Wrong Priority was used", 200, ExtensionHandlerBase.getLastPriorityUsed());
+    }
+}

--- a/src/test/java/org/apache/sling/feature/launcher/impl/FeatureProcessorTest.java
+++ b/src/test/java/org/apache/sling/feature/launcher/impl/FeatureProcessorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.sling.feature.launcher.impl;
 
 import org.apache.sling.feature.ArtifactId;

--- a/src/test/resources/META-INF/services/org.apache.sling.feature.launcher.spi.Launcher
+++ b/src/test/resources/META-INF/services/org.apache.sling.feature.launcher.spi.Launcher
@@ -1,0 +1,1 @@
+org.apache.sling.feature.launcher.impl.launchers.FrameworkLauncher

--- a/src/test/resources/META-INF/services/org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler
+++ b/src/test/resources/META-INF/services/org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler
@@ -1,0 +1,3 @@
+org.apache.sling.feature.launcher.handler.ExtensionHandlerDefault
+org.apache.sling.feature.launcher.handler.ExtensionHandler200
+org.apache.sling.feature.launcher.handler.ExtensionHandler100


### PR DESCRIPTION
The underlying issue is that so far we rely on the Class Loader order and that is not transparent.