### PR TITLE
SLING-10159: Remove handling of framework properties before the feature is processed

### DIFF
--- a/src/main/java/org/apache/sling/feature/launcher/impl/Bootstrap.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/Bootstrap.java
@@ -73,37 +73,10 @@ public class Bootstrap {
         this.config.getVariables().put("sling.home", this.config.getHomeDirectory().getAbsolutePath());
         if (this.config.getVariables().get("repository.home") == null) {
             this.config.getVariables().put("repository.home",
-                    this.config.getHomeDirectory().getAbsolutePath() + File.separatorChar + "repository");
+                this.config.getHomeDirectory().getAbsolutePath() + File.separatorChar + "repository");
         }
         this.config.getVariables().put("sling.launchpad",
-                this.config.getHomeDirectory().getAbsolutePath() + "/launchpad");
-
-        final Installation installation = this.config.getInstallation();
-        installation.setLogger(this.logger);
-
-        // set sling home, and use separate locations for launchpad and properties
-        installation.getFrameworkProperties().put("sling.home", this.config.getHomeDirectory().getAbsolutePath());
-        installation.getFrameworkProperties().put("sling.launchpad",
-                this.config.getHomeDirectory().getAbsolutePath() + "/launchpad");
-        if (!installation.getFrameworkProperties().containsKey("repository.home")) {
-            installation.getFrameworkProperties().put("repository.home",
-                    this.config.getHomeDirectory().getAbsolutePath() + File.separatorChar + "repository");
-        }
-        installation.getFrameworkProperties().put("sling.properties", "conf/sling.properties");
-        installation.getFrameworkProperties().put("sling.feature",
-                getApplicationFeatureFile(this.config).toURI().toString());
-
-
-        // additional OSGi properties
-        // move storage inside launcher
-        if ( installation.getFrameworkProperties().get(STORAGE_PROPERTY) == null ) {
-            installation.getFrameworkProperties().put(STORAGE_PROPERTY,
-                    this.config.getHomeDirectory().getAbsolutePath() + File.separatorChar + "framework");
-        }
-        // set start level to 30
-        if ( installation.getFrameworkProperties().get(START_LEVEL_PROP) == null ) {
-            installation.getFrameworkProperties().put(START_LEVEL_PROP, "30");
-        }
+            this.config.getHomeDirectory().getAbsolutePath() + "/launchpad");
     }
 
     public void run() {
@@ -256,6 +229,7 @@ public class Bootstrap {
         this.logger.info("");
 
         final Installation installation = config.getInstallation();
+        installation.setLogger(this.logger);
 
         // set sling home, and use separate locations for launchpad and properties
         installation.getFrameworkProperties().put("sling.home", config.getHomeDirectory().getAbsolutePath());
@@ -269,13 +243,12 @@ public class Bootstrap {
 
         // additional OSGi properties
         // move storage inside launcher
-        if ( installation.getFrameworkProperties().get(STORAGE_PROPERTY) == null ) {
-            installation.getFrameworkProperties().put(STORAGE_PROPERTY, config.getHomeDirectory().getAbsolutePath() + File.separatorChar + "framework");
-        }
+        installation.getFrameworkProperties()
+            .putIfAbsent(STORAGE_PROPERTY,  config.getHomeDirectory().getAbsolutePath() + File.separatorChar + "framework");
+
         // set start level to 30
-        if ( installation.getFrameworkProperties().get(START_LEVEL_PROP) == null ) {
-            installation.getFrameworkProperties().put(START_LEVEL_PROP, "30");
-        }
+        installation.getFrameworkProperties()
+            .putIfAbsent(START_LEVEL_PROP, "30");
 
         while (launcher.run(installation, createClassLoader(installation, launcher)) == FrameworkEvent.STOPPED_SYSTEM_REFRESHED) {
             this.logger.info("Framework restart due to extension refresh");

--- a/src/main/java/org/apache/sling/feature/launcher/impl/Bootstrap.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/Bootstrap.java
@@ -73,10 +73,25 @@ public class Bootstrap {
         this.config.getVariables().put("sling.home", this.config.getHomeDirectory().getAbsolutePath());
         if (this.config.getVariables().get("repository.home") == null) {
             this.config.getVariables().put("repository.home",
-                this.config.getHomeDirectory().getAbsolutePath() + File.separatorChar + "repository");
+                    this.config.getHomeDirectory().getAbsolutePath() + File.separatorChar + "repository");
         }
         this.config.getVariables().put("sling.launchpad",
-            this.config.getHomeDirectory().getAbsolutePath() + "/launchpad");
+                this.config.getHomeDirectory().getAbsolutePath() + "/launchpad");
+
+        final Installation installation = this.config.getInstallation();
+        installation.setLogger(this.logger);
+
+        // set sling home, and use separate locations for launchpad and properties
+        installation.getFrameworkProperties().put("sling.home", this.config.getHomeDirectory().getAbsolutePath());
+        installation.getFrameworkProperties().put("sling.launchpad",
+                this.config.getHomeDirectory().getAbsolutePath() + "/launchpad");
+        if (!installation.getFrameworkProperties().containsKey("repository.home")) {
+            installation.getFrameworkProperties().put("repository.home",
+                    this.config.getHomeDirectory().getAbsolutePath() + File.separatorChar + "repository");
+        }
+        installation.getFrameworkProperties().put("sling.properties", "conf/sling.properties");
+        installation.getFrameworkProperties().put("sling.feature",
+                getApplicationFeatureFile(this.config).toURI().toString());
     }
 
     public void run() {
@@ -229,7 +244,6 @@ public class Bootstrap {
         this.logger.info("");
 
         final Installation installation = config.getInstallation();
-        installation.setLogger(this.logger);
 
         // set sling home, and use separate locations for launchpad and properties
         installation.getFrameworkProperties().put("sling.home", config.getHomeDirectory().getAbsolutePath());


### PR DESCRIPTION
OSGi properties are being handled before `Installation#getFrameworkProperties()` is populated by parsing the Feature files using `FeatureProcessor#prepareLauncher()`. 

E.g. specifying framework properties such as **org.osgi.framework.startlevel.beginning** and **org.osgi.framework.storage** in **feature.json** file has no effect, the default values are used. These properties should be read from the feature


In the `prepare()` method `installation.getFrameworkProperties()` is empty.
<img width="431" alt="Capture" src="https://user-images.githubusercontent.com/24642899/108997486-f0659980-769f-11eb-8cd4-db3f84f1b797.PNG">


The duplicate code exists in the `run()` method, which is correct. 
