### PR TITLE
SLING-10211: add Bundle-Metadata, build with bnd

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
                  org.apache.johnzon.core.*,\
                  org.apache.johnzon.core.util.*,\
                  org.apache.sling.feature.*,\
-                 org.osgi.*,\
                  org.osgi.util.function.*,\
+                 org.osgi.util.converter.*,\
                  org.slf4j.*,\
                  org.slf4j.impl.*
                         ]]></bnd>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 
     <properties>
         <sling.java.version>8</sling.java.version>
+        <bnd.version>5.3.0</bnd.version>
     </properties>
 
     <scm>
@@ -41,34 +42,43 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                <execution>
-                    <id>unpack-dependencies</id>
-                    <phase>prepare-package</phase>
-                    <goals>
-                        <goal>unpack-dependencies</goal>
-                    </goals>
-                    <configuration>
-                        <excludes>META-INF/**</excludes>
-                        <outputDirectory>${project.build.directory}/classes</outputDirectory>
-                        <overWriteReleases>false</overWriteReleases>
-                        <overWriteSnapshots>true</overWriteSnapshots>
-                        <includeArtifactIds>osgi.core,commons-text,commons-lang3,org.apache.sling.feature,org.osgi.util.function,org.apache.felix.cm.json,org.apache.sling.commons.johnzon,org.apache.felix.converter,commons-cli,slf4j-api,slf4j-simple</includeArtifactIds>
+                <plugin>
+                    <groupId>biz.aQute.bnd</groupId>
+                    <artifactId>bnd-maven-plugin</artifactId>
+                        <configuration>
+                        <bnd><![CDATA[
+                 Main-Class: org.apache.sling.feature.launcher.impl.Main
+                -exportcontents:\
+                 org.apache.sling.feature.launcher.spi.*
+                -conditionalpackage:\
+                 javax.json*,\
+                 org.apache.commons.cli*,\
+                 org.apache.commons.lang3*,\
+                 org.apache.commons.text*,\
+                 org.apache.felix.cm.json*,\
+                 org.apache.felix.converter*,\
+                 org.apache.johnzon.core*,\
+                 org.apache.sling.feature*,\
+                 org.osgi.*,\
+                 org.osgi.util.function*,\
+                 org.slf4j.*,\
+                 org.slf4j.impl*
+                        ]]></bnd>
                     </configuration>
-                </execution>
-            </executions>
-            </plugin>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>bnd-process</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
                 <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>
-                        <manifest>
-                            <mainClass>org.apache.sling.feature.launcher.impl.Main</mainClass>
-                        </manifest>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
             </plugin>
@@ -151,6 +161,13 @@
             <artifactId>org.apache.sling.commons.johnzon</artifactId>
             <version>1.2.2</version>
             <scope>provided</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>biz.aQute.bnd</groupId>
+            <artifactId>biz.aQute.bndlib</artifactId>
+            <version>${bnd.version}</version>
+            <scope>compile</scope>
         </dependency>
 
         <!-- Testing dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
                  org.osgi.util.converter.*,\
                  org.slf4j.*,\
                  org.slf4j.impl.*
+                 Import-Package:\
+                 !org.osgi.framework.*,\
+                 !org.osgi.util.tracker.*,\
+                 !org.osgi.resource.*,\
+                 *
                         ]]></bnd>
                     </configuration>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -52,17 +52,18 @@
                  org.apache.sling.feature.launcher.spi.*
                 -conditionalpackage:\
                  javax.json*,\
-                 org.apache.commons.cli*,\
-                 org.apache.commons.lang3*,\
-                 org.apache.commons.text*,\
-                 org.apache.felix.cm.json*,\
-                 org.apache.felix.converter*,\
-                 org.apache.johnzon.core*,\
-                 org.apache.sling.feature*,\
+                 org.apache.commons.cli.*,\
+                 org.apache.commons.lang3.*,\
+                 org.apache.commons.text.*,\
+                 org.apache.felix.cm.json.*,\
+                 org.apache.felix.converter.*,\
+                 org.apache.johnzon.core.*,\
+                 org.apache.johnzon.core.util.*,\
+                 org.apache.sling.feature.*,\
                  org.osgi.*,\
-                 org.osgi.util.function*,\
+                 org.osgi.util.function.*,\
                  org.slf4j.*,\
-                 org.slf4j.impl*
+                 org.slf4j.impl.*
                         ]]></bnd>
                     </configuration>
                     <executions>
@@ -159,7 +160,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.commons.johnzon</artifactId>
-            <version>1.2.2</version>
+            <version>1.2.6</version>
             <scope>provided</scope>
         </dependency>
         

--- a/src/main/java/org/apache/sling/feature/launcher/impl/extensions/handlers/ContentPackageHandler.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/extensions/handlers/ContentPackageHandler.java
@@ -24,6 +24,9 @@ import org.apache.sling.feature.ExtensionType;
 import org.apache.sling.feature.launcher.spi.extensions.ExtensionContext;
 import org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
+
+@ServiceProvider(value =ExtensionHandler.class )
 public class ContentPackageHandler implements ExtensionHandler
 {
     @Override

--- a/src/main/java/org/apache/sling/feature/launcher/impl/extensions/handlers/RepoInitHandler.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/extensions/handlers/RepoInitHandler.java
@@ -24,6 +24,9 @@ import org.apache.sling.feature.ExtensionType;
 import org.apache.sling.feature.launcher.spi.extensions.ExtensionContext;
 import org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
+
+@ServiceProvider(value =ExtensionHandler.class )
 public class RepoInitHandler implements ExtensionHandler
 {
     private static final AtomicInteger index = new AtomicInteger(1);

--- a/src/main/java/org/apache/sling/feature/launcher/impl/launchers/FrameworkLauncher.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/launchers/FrameworkLauncher.java
@@ -31,9 +31,12 @@ import org.apache.sling.feature.launcher.spi.Launcher;
 import org.apache.sling.feature.launcher.spi.LauncherPrepareContext;
 import org.apache.sling.feature.launcher.spi.LauncherRunContext;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
+
 /**
  * Launcher directly using the OSGi launcher API.
  */
+@ServiceProvider(value = Launcher.class)
 public class FrameworkLauncher implements Launcher {
 
 

--- a/src/main/resources/META-INF/services/org.apache.sling.feature.launcher.spi.Launcher
+++ b/src/main/resources/META-INF/services/org.apache.sling.feature.launcher.spi.Launcher
@@ -1,1 +1,0 @@
-org.apache.sling.feature.launcher.impl.launchers.FrameworkLauncher

--- a/src/main/resources/META-INF/services/org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler
+++ b/src/main/resources/META-INF/services/org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler
@@ -1,2 +1,0 @@
-org.apache.sling.feature.launcher.impl.extensions.handlers.RepoInitHandler
-org.apache.sling.feature.launcher.impl.extensions.handlers.ContentPackageHandler


### PR DESCRIPTION
add a Bundle-Metadata to the feature-launcher
use bnd to generate Manifest
use bnd auto generate META-INF/services
use bnd conditionalimport to makes the jar smaller

old version of `sling-johnzon` did not include `org.apache.johnzon.core.util` update version from `1.2.2` to `1.2.6`