### PR TITLE
SLING-10323:  use alpine-jre as base image

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -18,7 +18,7 @@
 # -----------------------------------------------------------------------------
 
 #Base
-FROM adoptopenjdk/openjdk11:alpine-slim
+FROM adoptopenjdk/openjdk11:alpine-jre
 LABEL maintainer dev@sling.apache.org
 
 #ENV for Sling


### PR DESCRIPTION
switch from slim to jre because it is smaller and jre should be enough at runtime