### PR TITLE
SLING-11814: Add support for the -CO / --cacheOnly flag which only downloads the required dependency artifacts and does not actually start the framework

### DIFF
--- a/src/main/java/org/apache/sling/feature/launcher/impl/Bootstrap.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/Bootstrap.java
@@ -160,6 +160,11 @@ public class Bootstrap {
                         this.config.getLocalArtifacts(), this.config.getCachedArtifacts(),
                         this.config.getDownloadedArtifacts());
 
+                if (this.config.getCacheOnly()) {
+                    this.logger.info("Finished downloading any requirements...exiting!");
+                    System.exit(0);
+                }
+
                 if (restart) {
                     this.config.getInstallation().getInstallableArtifacts().clear();
                     this.config.getInstallation().getConfigurations().clear();

--- a/src/main/java/org/apache/sling/feature/launcher/impl/LauncherConfig.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/LauncherConfig.java
@@ -60,6 +60,8 @@ public class LauncherConfig
 
     private volatile ArtifactId launchFeatureId;
 
+    private volatile boolean cacheOnly = false;
+
     /**
      * Create a new configuration object.
      * Set the default values
@@ -148,5 +150,13 @@ public class LauncherConfig
      */
     public ArtifactId getLaunchFeatureId() {
         return this.launchFeatureId;
+    }
+
+    public boolean getCacheOnly() {
+        return this.cacheOnly;
+    }
+
+    public void setCacheOnly(final boolean value) {
+        this.cacheOnly = value;
     }
 }

--- a/src/main/java/org/apache/sling/feature/launcher/impl/Main.java
+++ b/src/main/java/org/apache/sling/feature/launcher/impl/Main.java
@@ -75,6 +75,8 @@ public class Main {
 
     public static final String OPT_LAUNCH_FEATURE_ID = "i";
 
+    public static final String OPT_CACHE_ONLY = "CO";
+
     private static Logger LOGGER;
 
     private static Options options;
@@ -208,6 +210,12 @@ public class Main {
                 .numberOfArgs(1)
                 .build();
 
+        final Option cacheOnlyOption = Option.builder(OPT_CACHE_ONLY)
+                .longOpt("cacheOnly")
+                .desc("Cache only the required dependencies. Don't start the framework.")
+                .optionalArg(true)
+                .build();
+
         final Option cacheOption = Option.builder(OPT_CACHE_DIR)
                 .longOpt("cache_dir")
                 .desc("Set cache dir")
@@ -258,6 +266,7 @@ public class Main {
                 .addOption(fwkProperties)
                 .addOption(varValue)
                 .addOption(debugOption)
+                .addOption(cacheOnlyOption)
                 .addOption(cacheOption)
                 .addOption(homeOption)
                 .addOption(extensionConfiguration)
@@ -267,6 +276,7 @@ public class Main {
 
         
         final CommandLineParser clp = new DefaultParser();
+
         try {
             final CommandLine cl = clp.parse(options, args);
 
@@ -302,6 +312,10 @@ public class Main {
                     }
                 });
             } // if not the `org.slf4j.simpleLogger.defaultLogLevel` is by default `info`
+
+            if (cl.hasOption(OPT_CACHE_ONLY)) {
+                    config.setCacheOnly(true);
+            }
 
             extractValuesFromOption(cl, OPT_FEATURE_FILES).orElseGet(ArrayList::new)
                     .forEach(config::addFeatureFiles);


### PR DESCRIPTION
This Pull Request introduces support for the `-CO` (`--cacheOnly`) parameter which, when specified, only caches the required dependency artifacts and does not start the entire Sling application. This feature can be used whenever the _complete_ set of dependency artifacts needs to be stored locally so that the Sling application can be entirely self-contained and not require connectivity to an external Maven repository for startup.

In our [CARDS](https://github.com/data-team-uhn/cards) project, this feature would be used to create completely self-contained Docker images of our project so that, once these images are pulled from a container registry, external network access would no longer be required.