### PR TITLE
SLING-13048: Make tests work in Java 21+

### DIFF
--- a/src/test/java/org/apache/sling/feature/launcher/impl/MainIT.java
+++ b/src/test/java/org/apache/sling/feature/launcher/impl/MainIT.java
@@ -27,14 +27,13 @@ import java.util.Map;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.sling.feature.ArtifactId;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -76,28 +75,6 @@ public class MainIT {
 
             super.checkExit(status);
             throw new SystemExitException(status);
-        }
-    }
-
-    private static boolean securityManagerIsSet;
-
-    @BeforeClass
-    public static void setUp() throws Exception {
-        try {
-            System.setSecurityManager(new NoSystemExitSecurityManager());
-            securityManagerIsSet = true;
-        } catch (UnsupportedOperationException e) {
-            // The security manager system is deprecated since Java 17
-            securityManagerIsSet = false;
-        }
-    }
-
-    @AfterClass
-    public static void tearDown() throws Exception {
-        try {
-            System.setSecurityManager(null);
-        } catch (UnsupportedOperationException e) {
-            // Not supported since Java 17
         }
     }
 
@@ -355,15 +332,19 @@ public class MainIT {
 
     @Test
     public void testMain_main() {
-        // The security manager mechanism is no longer functional in Java 17+.
-        // Without a security manager trapping the System.exit call,
-        // the whole VM would be shut down, which trips up Maven.
-        if (securityManagerIsSet) {
+        try {
+            System.setSecurityManager(new NoSystemExitSecurityManager());
             try {
                 Main.main(new String[] {});
+                fail("Invoking without any arguments should have failed.");
             } catch (SystemExitException e) {
                 assertEquals("Exit status", 1, e.status);
             }
+            System.setSecurityManager(null);
+        } catch (UnsupportedOperationException e) {
+            // The security manager mechanism is no longer functional in Java 17+.
+            // Without a security manager trapping the System.exit call,
+            // the whole VM would be shut down, which trips up Maven.
         }
     }
 }

--- a/src/test/java/org/apache/sling/feature/launcher/impl/MainIT.java
+++ b/src/test/java/org/apache/sling/feature/launcher/impl/MainIT.java
@@ -332,19 +332,19 @@ public class MainIT {
 
     @Test
     public void testMain_main() {
-        try {
-            System.setSecurityManager(new NoSystemExitSecurityManager());
-            try {
-                Main.main(new String[] {});
-                fail("Invoking without any arguments should have failed.");
-            } catch (SystemExitException e) {
-                assertEquals("Exit status", 1, e.status);
-            }
-            System.setSecurityManager(null);
-        } catch (UnsupportedOperationException e) {
+        if (Float.valueOf(System.getProperty("java.specification.version")) >= 17.0) {
             // The security manager mechanism is no longer functional in Java 17+.
             // Without a security manager trapping the System.exit call,
             // the whole VM would be shut down, which trips up Maven.
+            return;
         }
+        System.setSecurityManager(new NoSystemExitSecurityManager());
+        try {
+            Main.main(new String[] {});
+            fail("Invoking without any arguments should have failed.");
+        } catch (SystemExitException e) {
+            assertEquals("Exit status", 1, e.status);
+        }
+        System.setSecurityManager(null);
     }
 }

--- a/src/test/java/org/apache/sling/feature/launcher/impl/MainIT.java
+++ b/src/test/java/org/apache/sling/feature/launcher/impl/MainIT.java
@@ -79,16 +79,26 @@ public class MainIT {
         }
     }
 
+    private static boolean securityManagerIsSet;
+
     @BeforeClass
     public static void setUp() throws Exception {
-
-        System.setSecurityManager(new NoSystemExitSecurityManager());
+        try {
+            System.setSecurityManager(new NoSystemExitSecurityManager());
+            securityManagerIsSet = true;
+        } catch (UnsupportedOperationException e) {
+            // The security manager system is deprecated since Java 17
+            securityManagerIsSet = false;
+        }
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
-
-        System.setSecurityManager(null);
+        try {
+            System.setSecurityManager(null);
+        } catch (UnsupportedOperationException e) {
+            // Not supported since Java 17
+        }
     }
 
     @Test
@@ -345,11 +355,15 @@ public class MainIT {
 
     @Test
     public void testMain_main() {
-
-        try {
-            Main.main(new String[] {});
-        } catch (SystemExitException e) {
-            assertEquals("Exit status", 1, e.status);
+        // The security manager mechanism is no longer functional in Java 17+.
+        // Without a security manager trapping the System.exit call,
+        // the whole VM would be shut down, which trips up Maven.
+        if (securityManagerIsSet) {
+            try {
+                Main.main(new String[] {});
+            } catch (SystemExitException e) {
+                assertEquals("Exit status", 1, e.status);
+            }
         }
     }
 }

--- a/src/test/java/org/apache/sling/feature/launcher/impl/MainIT.java
+++ b/src/test/java/org/apache/sling/feature/launcher/impl/MainIT.java
@@ -26,7 +26,10 @@ import java.util.Map;
 
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.apache.commons.lang3.JavaVersion;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.sling.feature.ArtifactId;
+import org.junit.Assume;
 import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -332,12 +335,11 @@ public class MainIT {
 
     @Test
     public void testMain_main() {
-        if (Float.valueOf(System.getProperty("java.specification.version")) >= 17.0) {
-            // The security manager mechanism is no longer functional in Java 17+.
-            // Without a security manager trapping the System.exit call,
-            // the whole VM would be shut down, which trips up Maven.
-            return;
-        }
+        // The security manager mechanism is no longer functional after Java 17.
+        // Without a security manager trapping the System.exit call,
+        // the whole VM would be shut down, which trips up Maven.
+        Assume.assumeTrue(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17));
+
         System.setSecurityManager(new NoSystemExitSecurityManager());
         try {
             Main.main(new String[] {});


### PR DESCRIPTION
Quick and easy fix, just skip testing the exit status code when not possible.